### PR TITLE
Travis: use luacov-coveralls 0.1.1

### DIFF
--- a/.travis/setup_rocks.sh
+++ b/.travis/setup_rocks.sh
@@ -1,6 +1,6 @@
 luarocks install busted --local
 luarocks install luacov --local
-luarocks install luacov-coveralls --local
+luarocks install luacov-coveralls 0.1.1 --local
 luarocks install lua-llthreads2 --local
 luarocks install luaposix --local
 luarocks install lua-rote --local


### PR DESCRIPTION
New luacov-coveralls (0.2.0) produces empty coveralls reports.
See https://coveralls.io/builds/5045163
See https://github.com/moteus/luacov-coveralls/issues/1
