### PR TITLE
fix dependencies: lcurses, luajit, lua-term

### DIFF
--- a/.travis/setup_lua.sh
+++ b/.travis/setup_lua.sh
@@ -54,8 +54,8 @@ if [ "$LUAJIT" == "yes" ]; then
   make && make install PREFIX="$LUA_HOME_DIR"
 
   if [ "$LUA" == "luajit2.1" ]; then
-    ln -s $LUA_HOME_DIR/bin/luajit-2.1.0-beta1 $HOME/.lua/luajit
-    ln -s $LUA_HOME_DIR/bin/luajit-2.1.0-beta1 $HOME/.lua/lua;
+    ln -s $LUA_HOME_DIR/bin/luajit-2.1.0-beta2 $HOME/.lua/luajit
+    ln -s $LUA_HOME_DIR/bin/luajit-2.1.0-beta2 $HOME/.lua/lua;
   else
     ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/luajit
     ln -s $LUA_HOME_DIR/bin/luajit $HOME/.lua/lua;

--- a/.travis/setup_rocks.sh
+++ b/.travis/setup_rocks.sh
@@ -2,7 +2,7 @@ luarocks install busted --local
 luarocks install luacov --local
 luarocks install luacov-coveralls --local
 luarocks install lua-llthreads2 --local
-luarocks install luaposix --local
+luarocks install lcurses --local
 luarocks install lua-rote --local
 luarocks install alnbox --local
 luarocks install tree --local

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ install:
 # Downloand and install blast to c:\blast
 - call .appveyor\install_blast.bat
 - luarocks install "https://gist.githubusercontent.com/starius/719b194bb34ce612458c/raw/7ab5aa457164c5dccef2c06e0e06ffbed09319df/mediator_lua-1.1.1-0.rockspec"
+- luarocks install lua-term 0.3-1  # 0.4 is broken on Windows
 - luarocks install busted
 - luarocks install luacov
 - if "%LUA_SHORTV%"=="5.1" luarocks install bit32

--- a/lua-npge-dev-1.rockspec
+++ b/lua-npge-dev-1.rockspec
@@ -19,7 +19,7 @@ dependencies = {
 dependencies.platforms = {
     unix = {
         "alnbox",
-        "luaposix",
+        "lcurses",
     },
 }
 external_dependencies = {

--- a/src/npge/view/BlockInConsole.lua
+++ b/src/npge/view/BlockInConsole.lua
@@ -12,7 +12,7 @@ return function(block)
         table.insert(names, name)
     end
     --
-    local curses = require 'posix.curses'
+    local curses = require 'curses'
     local alnbox = require 'alnbox'
     local aln = alnbox.makeAlignment(names, name2text)
     local parameters = alnbox.alignmentParameters(aln, curses)


### PR DESCRIPTION
> posix.curses has been split back out into its own separate
> project again.

See http://lua-users.org/lists/lua-l/2016-02/msg00295.html