### PR TITLE
split "wrap" function into two parts

### DIFF
--- a/src/npge/cpp/lua_npge.cpp
+++ b/src/npge/cpp/lua_npge.cpp
@@ -20,15 +20,24 @@ using namespace lnpge;
 
 template<lua_CFunction F>
 struct wrap {
-    static int func(lua_State* L) {
+    static int func0(lua_State* L) {
         try {
             return F(L);
         } catch (std::exception& e) {
             lua_pushstring(L, e.what());
+            return -1;
         } catch (...) {
             lua_pushliteral(L, "Unknown exception");
+            return -1;
         }
-        return lua_error(L);
+    }
+
+    static int func(lua_State* L) {
+        int result = func0(L);
+        if (result == -1) {
+            return lua_error(L);
+        }
+        return result;
     }
 };
 


### PR DESCRIPTION
  * C++ part func0, which does try-catch
  * Lua part func, which calls lua_error

This fixes crash on LuaJIT on Visual Studio x86.

See http://www.freelists.org/post/luajit/LuaJIT-crashes-on-C-exceptions-in-Visual-Studio-32-bit-mode,6