### PR TITLE
travis: do not allow failure of LuaJIT 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ env:
     - LUA="luajit 2.0"
     - LUA="luajit 2.1"
 
-matrix:
-  allow_failures:
-    - env: LUA="luajit 2.1"
-
 before_install:
   - sudo apt-get update
   - wget https://raw.githubusercontent.com/mpeterv/hererocks/13e45c9db0293ac59ffb3756c0a883c7221e9295/hererocks.py


### PR DESCRIPTION
The bug in LuaJIT 2.1 was fixed in https://github.com/LuaJIT/LuaJIT/commit/01e4754962130dc85802a9738707d7fdb76c879c

See https://github.com/LuaJIT/LuaJIT/issues/193
See https://github.com/LuaJIT/LuaJIT/issues/183